### PR TITLE
fix Github repo url

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,7 +350,7 @@ ma partenership produttiva.<br>
         <div class="twelve columns">
             <p>Un repository Git dove condividere i pensieri codificati.</p>
             <div>
-                <a style="color: #000" href="https://github.com/socraten/microsocraten" class="button">Repository GitHub</a>
+                <a style="color: #000" href="https://github.com/socraten" class="button">Repository GitHub</a>
             </div>
         </div>
 


### PR DESCRIPTION
Nel sito il link al repository Github del gruppo punta al repository di uno specifico progetto invece che sulla pagina dell'organizzazione.